### PR TITLE
Reverse Proxy Service

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -67,7 +67,7 @@ services:
     expose:
       - port: 80
         accept:
-          - akashvpn.decentralized.win
+          - akashvpn.pupcakes.me
         to:
           - global: true
       - port: 992

--- a/deploy.yml
+++ b/deploy.yml
@@ -15,10 +15,12 @@ services:
           - global: true
       - port: 992
         as: 992
+        proto: tcp
         to:
           - service: caddy
       - port: 5555
         as: 5555
+        proto: tcp
         to:
           - service: caddy
       - port: 1194
@@ -57,7 +59,7 @@ services:
   # Reverse Proxy
   caddy:
     # Dockerfile: reverse_proxy/Dockerfile
-    image: programmerke/akash-vpn-caddy:0.0.15
+    image: programmerke/akash-vpn-caddy:0.0.16
     params:
       storage:
         data:
@@ -68,6 +70,32 @@ services:
           - akashvpn.decentralized.win
         to:
           - global: true
+      - port: 992
+        as: 992
+        proto: tcp
+        to:
+          - global: true
+      - port: 5555
+        as: 5555
+        proto: tcp
+        to:
+          - global: true
+      - port: 1194
+        as: 1194
+        proto: udp
+        to:
+          - global: true
+      - port: 500
+        as: 500
+        proto: udp
+        to:
+          - global: true
+      - port: 4500
+        as: 4500
+        proto: udp
+        to:
+          - global: true
+            
 
 profiles:
   compute:

--- a/deploy.yml
+++ b/deploy.yml
@@ -16,26 +16,26 @@ services:
       - port: 992
         as: 992
         to:
-          - global: true
+          - service: caddy
       - port: 5555
         as: 5555
         to:
-          - global: true
+          - service: caddy
       - port: 1194
         as: 1194
         proto: udp
         to:
-          - global: true
+          - service: caddy
       - port: 500
         as: 500
         proto: udp
         to:
-          - global: true
+          - service: caddy
       - port: 4500
         as: 4500
         proto: udp
         to:
-          - global: true
+          - service: caddy
 
   # Frontend Service (Next.js App)
   frontend:
@@ -44,7 +44,7 @@ services:
       - port: 3000
         as: 80
         to:
-          - global: true
+          - service: caddy
 
   # Documentation Service (Docusaurus)
   docs:
@@ -52,6 +52,20 @@ services:
     expose:
       - port: 80
         as: 80
+        to:
+          - service: caddy
+  # Reverse Proxy
+  caddy:
+    # Dockerfile: reverse_proxy/Dockerfile
+    image: programmerke/akash-vpn-caddy:0.0.15
+    params:
+      storage:
+        data:
+          mount: /data
+    expose:
+      - port: 80
+        accept:
+          - akashvpn.decentralized.win
         to:
           - global: true
 
@@ -84,7 +98,20 @@ profiles:
           size: 256Mi
         storage:
           size: 512Mi
-
+    # caddy compute profile
+    caddy-profile:
+      resources:
+        cpu:
+          units: 1.0
+        memory:
+          size: 512Mi
+        storage:
+          - size: 512Mi
+          - name: data
+            size: 1Gi
+            attributes:
+              persistent: true
+              class: beta3
   placement:
     akash:
       pricing:
@@ -97,6 +124,9 @@ profiles:
         docs-profile:
           denom: uakt
           amount: 5000
+        caddy-profile:
+          denom: uakt
+          amount: 10000
 
 deployment:
   softether:
@@ -110,4 +140,8 @@ deployment:
   docs:
     akash:
       profile: docs-profile
+      count: 1
+  caddy:
+    akash:
+      profile: caddy-profile
       count: 1

--- a/deploy.yml
+++ b/deploy.yml
@@ -17,27 +17,27 @@ services:
         as: 992
         proto: tcp
         to:
-          - service: caddy
+          - global: true
       - port: 5555
         as: 5555
         proto: tcp
         to:
-          - service: caddy
+          - global: true
       - port: 1194
         as: 1194
         proto: udp
         to:
-          - service: caddy
+          - global: true
       - port: 500
         as: 500
         proto: udp
         to:
-          - service: caddy
+          - global: true
       - port: 4500
         as: 4500
         proto: udp
         to:
-          - service: caddy
+          - global: true
 
   # Frontend Service (Next.js App)
   frontend:

--- a/deploy.yml
+++ b/deploy.yml
@@ -59,7 +59,7 @@ services:
   # Reverse Proxy
   caddy:
     # Dockerfile: reverse_proxy/Dockerfile
-    image: programmerke/akash-vpn-caddy:0.0.16
+    image: programmerke/akash-vpn-caddy:0.0.18
     params:
       storage:
         data:

--- a/deploy.yml
+++ b/deploy.yml
@@ -70,32 +70,6 @@ services:
           - akashvpn.pupcakes.me
         to:
           - global: true
-      - port: 992
-        as: 992
-        proto: tcp
-        to:
-          - global: true
-      - port: 5555
-        as: 5555
-        proto: tcp
-        to:
-          - global: true
-      - port: 1194
-        as: 1194
-        proto: udp
-        to:
-          - global: true
-      - port: 500
-        as: 500
-        proto: udp
-        to:
-          - global: true
-      - port: 4500
-        as: 4500
-        proto: udp
-        to:
-          - global: true
-            
 
 profiles:
   compute:

--- a/reverse_proxy/Caddyfile
+++ b/reverse_proxy/Caddyfile
@@ -11,27 +11,51 @@
 
 # VPN Ports
 
-:992 {
-       reverse_proxy softether:992
+{
+  layer4 {
+  
+    0.0.0.0:992 {
+      route {
+        proxy {
+	  upstream softether:992
+	}
+      }
+    }
+
+    0.0.0.0:5555 {
+      route {
+        proxy {
+	  upstream softether:5555
+	}
+      }
+    }
+
+    0.0.0.0:1194 {
+      route {
+        proxy {
+	  upstream softether:1194
+	}
+      }
+    }
+
+    0.0.0.0:500 {
+      route {
+        proxy {
+	  upstream softether:500
+	}
+      }
+    }
+
+    0.0.0.0:4500 {
+      route {
+        proxy {
+	  upstream softether:4500
+	}
+      }
+    }
+    
+  }
 }
-
-:5555 {
-       reverse_proxy softether:5555
-}
-
-
-:1194 {
-       reverse_proxy softether:1194
-}
-
-:500 {
-       reverse_proxy softether:500
-}
-
-:4500 {
-       reverse_proxy softether:4500
-}
-
 
 # web apps
 

--- a/reverse_proxy/Caddyfile
+++ b/reverse_proxy/Caddyfile
@@ -60,16 +60,19 @@
 # web apps
 
 :80 :443 {
-        # api
-        redir /api /api/
-        reverse_proxy /api/* api:80
+    encode zstd gzip
+    respond /healthz 200
 
-	# docs
-        redir /docs /docs/
-	reverse_proxy /docs/* docs:80
+    # api
+    redir /api /api/
+    reverse_proxy /api/* api:80
 
-	# landing page
-        reverse_proxy frontend:80
+    # docs
+    redir /docs /docs/
+    reverse_proxy /docs/* docs:80
+
+    # landing page
+    reverse_proxy frontend:80
 }
 
 # Refer to the Caddy docs for more information:

--- a/reverse_proxy/Caddyfile
+++ b/reverse_proxy/Caddyfile
@@ -1,0 +1,52 @@
+# The Caddyfile is an easy way to configure your Caddy web server.
+#
+# Unless the file starts with a global options block, the first
+# uncommented line is always the address of your site.
+#
+# To use your own domain name (with automatic HTTPS), first make
+# sure your domain's A/AAAA DNS records are properly pointed to
+# this machine's public IP, then replace ":80" below with your
+# domain name.
+
+
+# VPN Ports
+
+:992 {
+       reverse_proxy softether:992
+}
+
+:5555 {
+       reverse_proxy softether:5555
+}
+
+
+:1194 {
+       reverse_proxy softether:1194
+}
+
+:500 {
+       reverse_proxy softether:500
+}
+
+:4500 {
+       reverse_proxy softether:4500
+}
+
+
+# web apps
+
+:80 :443 {
+        # api
+        redir /api /api/
+        reverse_proxy /api/* api:80
+
+	# docs
+        redir /docs /docs/
+	reverse_proxy /docs/* docs:80
+
+	# landing page
+        reverse_proxy frontend:80
+}
+
+# Refer to the Caddy docs for more information:
+# https://caddyserver.com/docs/caddyfile

--- a/reverse_proxy/Dockerfile
+++ b/reverse_proxy/Dockerfile
@@ -1,3 +1,9 @@
-FROM caddy:2.10.2-alpine
+FROM caddy:2.10-builder-alpine AS builder
 
+RUN xcaddy build \
+    --with github.com/mholt/caddy-l4
+
+FROM caddy:2.10-alpine
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 COPY Caddyfile /etc/caddy/Caddyfile

--- a/reverse_proxy/Dockerfile
+++ b/reverse_proxy/Dockerfile
@@ -1,0 +1,3 @@
+FROM caddy:2.10.2-alpine
+
+COPY Caddyfile /etc/caddy/Caddyfile

--- a/reverse_proxy/README.md
+++ b/reverse_proxy/README.md
@@ -29,7 +29,7 @@ Deploy the SDL on Akash.
 
 *** Domain Name Configuration
 
-Configure TLS termination via cloudflare for the domain name above
+Configure TLS termination via Cloudflare for the domain name above,
 using [this][tls] guide on the Akash Documentaion.
 
 [tls]: https://akash.network/docs/guides/deployments/tls-termination-of-akash-deployment/

--- a/reverse_proxy/README.md
+++ b/reverse_proxy/README.md
@@ -1,0 +1,35 @@
+* Reverse Proxy
+
+This describes how to setup the Caddy reverse proxy for Akash VPN.
+
+** Setup
+
+*** Docker Image
+
+Prepare the docker image.
+
+- Build the docker image from the [Dockerfile](Dockerfile)
+
+`docker build -t <image_name>:<tag> .`
+
+- Push the docker image to the registry
+
+`docker push <image_name>:<tag>`
+
+*** SDL
+
+Update the [SDL](../deploy.yml)
+
+- Set the caddy service image name to the above image.
+
+- Set the caddy service exposed port 80 to accept connections from the
+  Akash VPN domain name.
+  
+Deploy the SDL on Akash.
+
+*** Domain Name Configuration
+
+Configure TLS termination via cloudflare for the domain name above
+using [this][tls] guide on the Akash Documentaion.
+
+[tls]: https://akash.network/docs/guides/deployments/tls-termination-of-akash-deployment/

--- a/reverse_proxy/README.md
+++ b/reverse_proxy/README.md
@@ -1,10 +1,10 @@
-* Reverse Proxy
+# Reverse Proxy
 
 This describes how to setup the Caddy reverse proxy for Akash VPN.
 
-** Setup
+## Setup
 
-*** Docker Image
+### Docker Image
 
 Prepare the docker image.
 
@@ -16,7 +16,7 @@ Prepare the docker image.
 
 `docker push <image_name>:<tag>`
 
-*** SDL
+### SDL
 
 Update the [SDL](../deploy.yml)
 
@@ -27,7 +27,7 @@ Update the [SDL](../deploy.yml)
   
 Deploy the SDL on Akash.
 
-*** Domain Name Configuration
+### Domain Name Configuration
 
 Configure TLS termination via Cloudflare for the domain name above,
 using [this][tls] guide on the Akash Documentaion.


### PR DESCRIPTION
## What changed?
Added a reverse proxy (caddy) to the SDL 

## Why?
<!-- Reason for change -->
To have a single entry point to the various backend services.

### Changes proposed

Setup a reverse proxy with routing and TLS termination:

- Added Caddy as a reverse proxy to the SDL
- Set up TLS termination via Cloudflare (seems like this is the only viable method)

Temporary deployment set up at https://akashvpn.decentralized.win/

NB:
- The api service is yet to be added to the SDL
- The docs endpoint displays with broken styling because docs service static assets are yet to be set up to serve under the `/docs` base url.

Changed SDL file `deploy.yml` in the projject root
Added new files in the `reverse_proxy` subdirectory.

## Checklist
- [x] Follows Conventional Commits
- [x] Verified changes locally
- [x] What changes were proposed
- [x] What you did to address them
- [x] Link to the relevant lines of code that resolve the issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Caddy reverse-proxy consolidating web (/, /api, /docs) and VPN ports (992, 5555, 1194, 500, 4500) behind akashvpn.pupcakes.me with HTTPS; frontend and docs now routed through the proxy. SoftEther ports proxied with TCP.

* **Documentation**
  * Added a guide for building/pushing the proxy image and configuring domain/TLS and deployment steps.

* **Chores**
  * Added compute profile, storage, placement/pricing and deployed the proxy service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->