### PR TITLE
fix: resolve Docker build tag validation errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
@@ -129,7 +129,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
@@ -181,7 +181,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
@@ -233,7 +233,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 


### PR DESCRIPTION
- Fix invalid Docker tag format in GitHub Actions workflow
- Change 'type=sha,prefix={{branch}}-' to 'type=sha,prefix=sha-'
- Prevents tags starting with dashes when branch names have special characters
- Applied to all services: frontend, backend, docs, caddy

Resolves build failure: 'invalid tag format' error

## What changed?
<!-- Brief description -->

## Why?
<!-- Reason for change -->

## Checklist
- [ x ] Follows Conventional Commits
- [ x ] Verified changes locally
- [ x ] What changes were proposed
- [ x ] What you did to address them
- [ x ] Link to the relevant lines of code that resolve the issue
