### PR TITLE
fix: improve OpenVPN certificate formatting and config generation

### DIFF
--- a/frontend/src/components/connection-controls.tsx
+++ b/frontend/src/components/connection-controls.tsx
@@ -91,7 +91,7 @@ export function ConnectionControls() {
   }, []);
 
   const downloadConfig = (server: Server) => {
-    let configContent = `# --------------------- CUT HERE -------------------------------
+    let configContent = `# ${server.region.toLowerCase().replace(/\s+/g, '-')}.ovpn
 dev tun
 proto tcp
 remote ${server.hostname} ${server.external_port}
@@ -104,17 +104,10 @@ persist-tun
 client
 verb 3
 auth-user-pass
+<ca>
+${server.ca_certificate}
+</ca>
 `;
-
-    // Add CA certificate if available
-    if (server.ca_certificate) {
-      configContent += `<ca>\n${server.ca_certificate}\n</ca>\n`;
-      console.log('CA certificate added to config');
-    } else {
-      console.log('No CA certificate found');
-    }
-
-    configContent += `# --------------------- CUT HERE -------------------------------`;
 
     const blob = new Blob([configContent], { type: 'application/x-openvpn-profile' });
     const url = URL.createObjectURL(blob);

--- a/server/app.js
+++ b/server/app.js
@@ -13,7 +13,14 @@ var app = express();
 
 // Enable CORS for all routes
 app.use(cors({
-  origin: process.env.FRONTEND_URL || 'http://localhost:4000',
+  origin: (origin, callback) => {
+    // Allow all localhost origins in development
+    if (!origin || origin.startsWith('http://localhost:') || origin.startsWith('https://localhost:')) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
   credentials: true
 }));
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -48,8 +48,14 @@ router.get('/api/v2ray-qr/:serverId', async function (req, res) {
         return cert;
       }
 
+      // Clean the certificate data more aggressively
+      // Remove all whitespace, line breaks, and non-base64 characters
+      let cleanCert = cert.replace(/[^A-Za-z0-9+/=]/g, '');
+
+      // Don't remove padding characters - they're essential for base64
+
       // Format the certificate with proper line breaks (64 characters per line)
-      const formatted = cert.replace(/(.{64})/g, '$1\n');
+      const formatted = cleanCert.replace(/(.{64})/g, '$1\n');
       return `-----BEGIN CERTIFICATE-----\n${formatted}\n-----END CERTIFICATE-----`;
     };
 
@@ -254,8 +260,14 @@ router.get('/api/regions', (req, res) => {
         return cert;
       }
 
+      // Clean the certificate data more aggressively
+      // Remove all whitespace, line breaks, and non-base64 characters
+      let cleanCert = cert.replace(/[^A-Za-z0-9+/=]/g, '');
+
+      // Don't remove padding characters - they're essential for base64
+
       // Format the certificate with proper line breaks (64 characters per line)
-      const formatted = cert.replace(/(.{64})/g, '$1\n');
+      const formatted = cleanCert.replace(/(.{64})/g, '$1\n');
       return `-----BEGIN CERTIFICATE-----\n${formatted}\n-----END CERTIFICATE-----`;
     };
 
@@ -327,6 +339,30 @@ router.get('/api/regions', (req, res) => {
           v2ray: hasRealV2RayUUID(getEnvVar('SOUTH_CAROLINA_V2RAY_UUID')) ? {
             uuid: getEnvVar('SOUTH_CAROLINA_V2RAY_UUID'),
             ports: [safeParseInt(process.env.SOUTH_CAROLINA_V2RAY_PORT, 1010)],
+            protocol: "vmess",
+            security: "auto",
+            network: "tcp"
+          } : null
+        }]
+      });
+    }
+
+    // Switzerland Server
+    if (getEnvVar('SWITZERLAND_HOSTNAME')) {
+      countries.push({
+        country: "Switzerland",
+        country_code: "CH",
+        flag: "🇨🇭",
+        servers: [{
+          region: "Switzerland Server",
+          hostname: getEnvVar('SWITZERLAND_HOSTNAME'),
+          external_port: safeParseInt(process.env.SWITZERLAND_PORT, 1194),
+          hub_name: "AKASH_HUB",
+          ca_certificate: formatCACertificate(getEnvVar('SWITZERLAND_CA_CERT')),
+          _comment: `VPN Credentials: Username: ${getEnvVar('SWITZERLAND_USERNAME', 'N/A')}, Password: ${getEnvVar('SWITZERLAND_PASSWORD', 'N/A')}`,
+          v2ray: hasRealV2RayUUID(getEnvVar('SWITZERLAND_V2RAY_UUID')) ? {
+            uuid: getEnvVar('SWITZERLAND_V2RAY_UUID'),
+            ports: [safeParseInt(process.env.SWITZERLAND_V2RAY_PORT, 1010)],
             protocol: "vmess",
             security: "auto",
             network: "tcp"


### PR DESCRIPTION
- Fix certificate cleaning to preserve base64 padding characters
- Remove 'cut here' comments from generated OpenVPN files
- Improve certificate formatting function to handle malformed certs
- Update CORS configuration to allow all localhost origins
- Add Switzerland server support to backend and frontend
- Fix OpenVPN config structure to match working format

## What changed?
<!-- Brief description -->

## Why?
<!-- Reason for change -->

## Checklist
- [ ] Follows Conventional Commits
- [ ] Verified changes locally
- [ ] What changes were proposed
- [ ] What you did to address them
- [ ] Link to the relevant lines of code that resolve the issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Switzerland server region support when configured via environment settings.

- Bug Fixes
  - Always embed the CA certificate in downloaded OpenVPN configs for consistent compatibility.
  - Clean and correctly wrap CA certificate data to prevent malformed certificates.
  - Hardened CORS behavior: allow localhost origins (http/https) and block non-local origins while retaining credential support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->